### PR TITLE
readme fixes + cmake workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,217 +3,85 @@ on:
   push:
     branches:
       - master
-      - continuous-delivery
 
-jobs: 
-  OGL-x86:
-    runs-on: windows-2022
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
-      - name: Download libogg, libvorbis, and libtheora for easier includes
-        run: |
-          Invoke-WebRequest -Uri "https://ftp.osuosl.org/pub/xiph/releases/ogg/libogg-1.3.5.zip" -OutFile "libogg.zip"
-          Expand-Archive -Path libogg.zip -DestinationPath ./dependencies/windows/
-          Rename-Item ./dependencies/windows/libogg-1.3.5 libogg
-          Invoke-WebRequest -Uri "https://ftp.osuosl.org/pub/xiph/releases/vorbis/libvorbis-1.3.7.zip" -OutFile "libvorbis.zip"
-          Expand-Archive -Path libvorbis.zip -DestinationPath ./dependencies/windows/
-          Rename-Item ./dependencies/windows/libvorbis-1.3.7 libvorbis
-          Invoke-WebRequest -Uri "https://ftp.osuosl.org/pub/xiph/releases/theora/libtheora-1.1.1.zip" -OutFile "libtheora.zip"
-          Expand-Archive -Path libtheora.zip -DestinationPath ./dependencies/windows/
-          Rename-Item ./dependencies/windows/libtheora-1.1.1 libtheora
-      - name: Download GLEW
-        run: |
-          Invoke-WebRequest -Uri "https://github.com/nigels-com/glew/releases/download/glew-2.2.0/glew-2.2.0-win32.zip" -OutFile "GLEW.zip"
-          Expand-Archive -Path GLEW.zip -DestinationPath ./dependencies/windows/
-          Rename-Item ./dependencies/windows/glew-2.2.0 glew
-      - name: Download SDL2
-        run: |
-          Invoke-WebRequest -Uri "https://libsdl.org/release/SDL2-devel-2.28.3-VC.zip" -OutFile "SDL2.zip"
-          Expand-Archive -Path SDL2.zip -DestinationPath ./dependencies/windows/
-          Rename-Item ./dependencies/windows/SDL2-2.28.3 SDL2
-      - name: Run vcpkg
-        run: |
-          vcpkg install libogg:x86-windows-static libvorbis:x86-windows-static libtheora:x86-windows-static
-          vcpkg integrate install
-      - name: Build RSDKv3
-        run: |
-          msbuild RSDKv3.sln -target:RSDKv3-OGL /p:Configuration=Release /p:Platform=x86 /p:ForceImportBeforeCppTargets="$env:GITHUB_WORKSPACE/props/winactions.props"
-      - name: Move artifacts
-        run: |
-          mkdir artifacts
-          move ./build/Win32/Release/OGL/*.dll ./artifacts
-          move ./build/Win32/Release/OGL/*.exe ./artifacts
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: OGL-x86
-          path: artifacts
-  OGL-x64:
-    runs-on: windows-2022
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
-      - name: Download libogg, libvorbis, and libtheora for easier includes
-        run: |
-          Invoke-WebRequest -Uri "https://ftp.osuosl.org/pub/xiph/releases/ogg/libogg-1.3.5.zip" -OutFile "libogg.zip"
-          Expand-Archive -Path libogg.zip -DestinationPath ./dependencies/windows/
-          Rename-Item ./dependencies/windows/libogg-1.3.5 libogg
-          Invoke-WebRequest -Uri "https://ftp.osuosl.org/pub/xiph/releases/vorbis/libvorbis-1.3.7.zip" -OutFile "libvorbis.zip"
-          Expand-Archive -Path libvorbis.zip -DestinationPath ./dependencies/windows/
-          Rename-Item ./dependencies/windows/libvorbis-1.3.7 libvorbis
-          Invoke-WebRequest -Uri "https://ftp.osuosl.org/pub/xiph/releases/theora/libtheora-1.1.1.zip" -OutFile "libtheora.zip"
-          Expand-Archive -Path libtheora.zip -DestinationPath ./dependencies/windows/
-          Rename-Item ./dependencies/windows/libtheora-1.1.1 libtheora
-      - name: Download GLEW
-        run: |
-          Invoke-WebRequest -Uri "https://github.com/nigels-com/glew/releases/download/glew-2.2.0/glew-2.2.0-win32.zip" -OutFile "GLEW.zip"
-          Expand-Archive -Path GLEW.zip -DestinationPath ./dependencies/windows/
-          Rename-Item ./dependencies/windows/glew-2.2.0 glew
-      - name: Download SDL2
-        run: |
-          Invoke-WebRequest -Uri "https://libsdl.org/release/SDL2-devel-2.28.3-VC.zip" -OutFile "SDL2.zip"
-          Expand-Archive -Path SDL2.zip -DestinationPath ./dependencies/windows/
-          Rename-Item ./dependencies/windows/SDL2-2.28.3 SDL2
-      - name: Run vcpkg
-        run: |
-          vcpkg install libogg:x64-windows-static libvorbis:x64-windows-static libtheora:x64-windows-static
-          vcpkg integrate install
-      - name: Build RSDKv3
-        run: |
-          msbuild RSDKv3.sln -target:RSDKv3-OGL /p:Configuration=Release /p:Platform=x64 /p:ForceImportBeforeCppTargets="$env:GITHUB_WORKSPACE/props/winactions_x64.props"
-      - name: Move artifacts
-        run: |
-          mkdir artifacts
-          move ./build/x64/Release/OGL/*.dll ./artifacts
-          move ./build/x64/Release/OGL/*.exe ./artifacts
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: OGL-x64
-          path: artifacts
-  SDL2-x64:
-    runs-on: windows-2022
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
-      - name: Download libogg, libvorbis, and libtheora for easier includes
-        run: |
-          Invoke-WebRequest -Uri "https://ftp.osuosl.org/pub/xiph/releases/ogg/libogg-1.3.5.zip" -OutFile "libogg.zip"
-          Expand-Archive -Path libogg.zip -DestinationPath ./dependencies/windows/
-          Rename-Item ./dependencies/windows/libogg-1.3.5 libogg
-          Invoke-WebRequest -Uri "https://ftp.osuosl.org/pub/xiph/releases/vorbis/libvorbis-1.3.7.zip" -OutFile "libvorbis.zip"
-          Expand-Archive -Path libvorbis.zip -DestinationPath ./dependencies/windows/
-          Rename-Item ./dependencies/windows/libvorbis-1.3.7 libvorbis
-          Invoke-WebRequest -Uri "https://ftp.osuosl.org/pub/xiph/releases/theora/libtheora-1.1.1.zip" -OutFile "libtheora.zip"
-          Expand-Archive -Path libtheora.zip -DestinationPath ./dependencies/windows/
-          Rename-Item ./dependencies/windows/libtheora-1.1.1 libtheora
-      - name: Download GLEW
-        run: |
-          Invoke-WebRequest -Uri "https://github.com/nigels-com/glew/releases/download/glew-2.2.0/glew-2.2.0-win32.zip" -OutFile "GLEW.zip"
-          Expand-Archive -Path GLEW.zip -DestinationPath ./dependencies/windows/
-          Rename-Item ./dependencies/windows/glew-2.2.0 glew
-      - name: Download SDL2
-        run: |
-          Invoke-WebRequest -Uri "https://libsdl.org/release/SDL2-devel-2.28.3-VC.zip" -OutFile "SDL2.zip"
-          Expand-Archive -Path SDL2.zip -DestinationPath ./dependencies/windows/
-          Rename-Item ./dependencies/windows/SDL2-2.28.3 SDL2
-      - name: Run vcpkg
-        run: |
-          vcpkg install libogg:x64-windows-static libvorbis:x64-windows-static libtheora:x64-windows-static
-          vcpkg integrate install
-      - name: Build RSDKv3
-        run: |
-          msbuild RSDKv3.sln -target:RSDKv3-SDL2 /p:Configuration=Release /p:Platform=x64 /p:ForceImportBeforeCppTargets="$env:GITHUB_WORKSPACE/props/winactions_x64.props"
-      - name: Move artifacts
-        run: |
-          mkdir artifacts
-          move ./build/x64/Release/SDL2/*.dll ./artifacts
-          move ./build/x64/Release/SDL2/*.exe ./artifacts
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: SDL2-x64
-          path: artifacts
-  v3-android:
+env:
+  GENERAL_FLAGS: "-DRETRO_DISABLE_PLUS=ON -DCMAKE_BUILD_TYPE=Release"
+  # Normally you would use $VCPKG_INSTALLATION_PATH, but it's broken...so hardcode C:/vcpkg
+  GENERAL_WIN_FLAGS: "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
+  WIN32_FLAGS: "-DVCPKG_TARGET_TRIPLET=x86-windows-static -DCMAKE_PREFIX_PATH=C:/vcpkg/installed/x86-windows-static/ -A Win32"
+  WIN64_FLAGS: "-DVCPKG_TARGET_TRIPLET=x64-windows-static -DCMAKE_PREFIX_PATH=C:/vcpkg/installed/x64-windows-static/"
+  # FIXME: For some reason ubuntu enables _FORTIFY_SOURCE by default, so let's override it to prevent IO bugs
+  GENERAL_LINUX_FLAGS: "-DCMAKE_CXX_FLAGS='-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0'"
+
+jobs:
+  v3-windows:
     runs-on: windows-latest
     steps:
-      - name: Checkout repository Android
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
-      - name: Download libogg, libvorbis, and libtheora for easier includes
+      - name: Install dependencies
+        run: vcpkg install glew sdl2 libogg libtheora libvorbis --triplet=x86-windows-static
+      - name: Build RSDKv3
         run: |
-          Invoke-WebRequest -Uri "https://ftp.osuosl.org/pub/xiph/releases/vorbis/libvorbis-1.3.7.zip" -OutFile "libvorbis.zip"
-          Expand-Archive -Path libvorbis.zip -DestinationPath ./dependencies/android/
-          Rename-Item ./dependencies/android/libvorbis-1.3.7 libvorbis
-          Invoke-WebRequest -Uri "https://ftp.osuosl.org/pub/xiph/releases/ogg/libogg-1.3.5.zip" -OutFile "libogg.zip"
-          Expand-Archive -Path libogg.zip -DestinationPath ./dependencies/android/app/jni/src/dependencies/android/
-          Rename-Item ./dependencies/android/app/jni/src/dependencies/android/libogg-1.3.5 libogg
-          Invoke-WebRequest -Uri "https://ftp.osuosl.org/pub/xiph/releases/theora/libtheora-1.1.1.zip" -OutFile "libtheora.zip"
-          Expand-Archive -Path libtheora.zip -DestinationPath ./dependencies/android
-          Rename-Item ./dependencies/android/libtheora-1.1.1 libtheora
-      - name: Download GLEW
+          cmake -B build ${{env.GENERAL_FLAGS}} ${{env.GENERAL_WIN_FLAGS}} ${{env.WIN32_FLAGS}}
+          cmake --build build --parallel --config Release
+      - name: Move artifacts
         run: |
-          Invoke-WebRequest -Uri "https://github.com/nigels-com/glew/releases/download/glew-2.2.0/glew-2.2.0-win32.zip" -OutFile "GLEW.zip"
-          Expand-Archive -Path GLEW.zip -DestinationPath ./dependencies/android/
-          Rename-Item ./dependencies/android/glew-2.2.0 glew
-      - name: Download SDL2
-        run: |
-          Invoke-WebRequest -Uri "https://libsdl.org/release/SDL2-2.28.3.zip" -OutFile "SDL2.zip"
-          Expand-Archive -Path SDL2.zip -DestinationPath ./android/app/jni/
-          Rename-Item ./android/app/jni/SDL2-2.28.3 SDL
-      - name: Move & Copy stuff
-        run: |
-          Copy-Item -Path ./dependencies/all/theoraplay -Destination ./dependencies/android/app/jni/src/dependencies/android/
-          Copy-Item -Path ./dependencies/android/app/jni/src/dependencies/android\* -Destination ./dependencies/
-          Copy-Item -Path ./dependencies/android/app/jni/src/dependencies/android/libogg/ -Destination ./dependencies/android/ -recurse
-          Copy-Item -Path ./dependencies/android/config_types.h -Destination ./dependencies/android/libogg/include/ogg/
-      - name: Set up Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: "zulu"
-          java-version: 11
-      - name: Build RSDKv3 Android
-        working-directory: ./android
-        run: |
-          ./gradlew.bat assembleDebug --no-daemon -PABIFILTERS="armeabi-v7a;arm64-v8a" -PRETRO_DISABLE_PLUS
-      - name: Upload artifact Android
+          mkdir artifacts
+          mv ./build/Release/*.exe ./artifacts
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: v3-android
-          path: ./android/app/build/outputs/apk
+          name: v3-windows
+          path: artifacts
+  v3-windows-x64:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: vcpkg install glew sdl2 libogg libtheora libvorbis --triplet=x64-windows-static
+      - name: Build RSDKv3
+        run: |
+          cmake -B build ${{env.GENERAL_FLAGS}} ${{env.GENERAL_WIN_FLAGS}} ${{env.WIN64_FLAGS}}
+          cmake --build build --parallel --config Release
+      - name: Move artifacts
+        run: |
+          mkdir artifacts
+          mv ./build/Release/*.exe ./artifacts
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: v3-windows-x64
+          path: artifacts
   v3-linux:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install libtheora-dev libogg-dev libvorbis-dev libsdl2-dev libglew-dev
-          ls ./dependencies/all
+          sudo apt-get install libglew-dev libglfw3-dev libsdl2-dev libogg-dev libtheora-dev libvorbis-dev
       - name: Build RSDKv3
         run: |
-          make RETRO_DISABLE_PLUS=1
-      - name: Upload artifact
+          cmake -B build ${{env.GENERAL_FLAGS}} ${{env.GENERAL_LINUX_FLAGS}}
+          cmake --build build --parallel
+      # tar the executables so that they don't lose exec permissions
+      # see: https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss
+      - name: Move artifacts
+        run: |
+          mkdir artifacts
+          mv ./build/RSDKv3* ./artifacts
+          tar -czvf linux.tar.gz -C ./artifacts .
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: v3-linux
-          path: bin
+          path: linux.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build RSDKv3
+name: Build Sonic CD Restored
 on:
   push:
     branches:
@@ -78,7 +78,7 @@ jobs:
       - name: Move artifacts
         run: |
           mkdir artifacts
-          mv ./build/RSDKv3* ./artifacts
+          mv ./build/"Sonic CD Restored"* ./artifacts
           tar -czvf linux.tar.gz -C ./artifacts .
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if(RETRO_ORIGINAL_CODE)
     set(RETRO_MOD_LOADER OFF)
 endif()
 
-set(RETRO_NAME "RSDKv3")
+set(RETRO_NAME "Sonic CD Restored")
 
 set(RETRO_OUTPUT_NAME ${RETRO_NAME} CACHE STRING "The exported name of the executable.")
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Install the following dependencies: then follow the [compilation steps below](#c
 ## Android
 > [!WARNING]
 Building for this platform is unsupported and probably won't function correctly anyway.
+
 Follow the android build instructions [here.](./dependencies/android/README.md)
 
 ### Compiling

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you've already cloned the repo, run this command inside of the repository:
 ## Follow the build steps
 
 ### Windows
-To handle dependencies, you'll need to install [Visual Studio Community](https://visualstudio.microsoft.com/downloads/) (make sure to install the `Desktop development with C++` package during the installation) and [vcpkg](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started) (only up to the substeps seen in step 1. 
+To handle dependencies, you'll need to install [Visual Studio Community](https://visualstudio.microsoft.com/downloads/) (make sure to install the `Desktop development with C++` package during the installation) and [vcpkg](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started) (only up to the substeps seen in step 1). 
 
 After installing those, run the following in Command Prompt (make sure to replace `[vcpkg root]` with the path to the vcpkg installation!):
 - `[vcpkg root]\vcpkg.exe install glew sdl2 libogg libtheora libvorbis --triplet=x64-windows-static` (If you're compiling a 32-bit build, replace `x64-windows-static` with `x86-windows-static`.)
@@ -96,7 +96,6 @@ cmake --build build --config release
 The resulting build will be located somewhere in `build/` depending on your system.
 
 The following cmake arguments are available when compiling:
-- Use these on the first `cmake -B build` step like so: `cmake -B build -DRETRO_DISABLE_PLUS=on`
 
 ### RSDKv3 flags
 - `RETRO_DISABLE_PLUS`: Whether or not to disable the Plus DLC. Takes a boolean (on/off): build with `on` when compiling for distribution. Defaults to `off`.
@@ -105,6 +104,8 @@ The following cmake arguments are available when compiling:
 - `RETRO_USE_HW_RENDER`: Enables the Hardware Renderer as an option. Takes a boolean, defaults to `on`.
 - `RETRO_ORIGINAL_CODE`: Removes any custom code. *A playable game will not be built with this enabled.* Takes a boolean, defaults to `off`.
 - `RETRO_SDL_VERSION`: *Only change this if you know what you're doing.* Switches between using SDL1 or SDL2. Takes an integer of either `1` or `2`, defaults to `2`.
+
+- Use these on the first `cmake -B build` step like so: `cmake -B build -DRETRO_DISABLE_PLUS=on`
 
 ## Unofficial Branches
 Follow the installation instructions in the readme of each branch.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Install the following dependencies: then follow the [compilation steps below](#c
 - Your favorite package manager here, [make a pull request](https://github.com/FawkesRocks/New_Sonic_CD-R_Decompilation/fork)
 
 ## Android
+> [!WARNING]
+Building for this platform is unsupported and probably won't function correctly anyway.
 Follow the android build instructions [here.](./dependencies/android/README.md)
 
 ### Compiling
@@ -96,7 +98,8 @@ cmake --build build --config release
 The resulting build will be located somewhere in `build/` depending on your system.
 
 > [!NOTE]
-You can use these arguments on the `cmake -B build` command like so: `cmake -B build -DRETRO_DISABLE_PLUS=on`
+You can use these arguments on the `cmake -B build` command like so:
+`cmake -B build -DRETRO_DISABLE_PLUS=on`
 
 The following cmake arguments are available when compiling:
 - `RETRO_DISABLE_PLUS`: Whether or not to disable the Plus DLC. Takes a boolean (on/off): build with `on` when compiling for distribution. Defaults to `off`.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This project uses [CMake](https://cmake.org/), a versatile building system that 
 In order to clone the repository, you need to install Git, which you can get [here](https://git-scm.com/downloads).
 
 Clone the repo **recursively**, using:
-`git clone --recursive https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation`
+`git clone --recursive https://github.com/FawkesRocks/New_Sonic_CD-R_Decompilation`
 
 If you've already cloned the repo, run this command inside of the repository:
 ```git submodule update --init --recursive```
@@ -59,7 +59,7 @@ If you've already cloned the repo, run this command inside of the repository:
 ## Follow the build steps
 
 ### Windows
-To handle dependencies, you'll need to install [Visual Studio Community](https://visualstudio.microsoft.com/downloads/) (make sure to install the `Desktop development with C++` package during the installation) and [vcpkg](https://github.com/microsoft/vcpkg#quick-start-windows).
+To handle dependencies, you'll need to install [Visual Studio Community](https://visualstudio.microsoft.com/downloads/) (make sure to install the `Desktop development with C++` package during the installation) and [vcpkg](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started) (only up to the substeps seen in step 1. 
 
 After installing those, run the following in Command Prompt (make sure to replace `[vcpkg root]` with the path to the vcpkg installation!):
 - `[vcpkg root]\vcpkg.exe install glew sdl2 libogg libtheora libvorbis --triplet=x64-windows-static` (If you're compiling a 32-bit build, replace `x64-windows-static` with `x86-windows-static`.)
@@ -74,20 +74,20 @@ Install the following dependencies: then follow the [compilation steps below](#c
 - **apt (Debian/Ubuntu):** `sudo apt install build-essential cmake libglew-dev libglfw3-dev libsdl2-dev libogg-dev libtheora-dev libvorbis-dev`
 - **rpm (Fedora):** `sudo dnf install make gcc cmake glew-devel glfw-devel sdl2-devel libogg-devel libtheora-devel libvorbis-devel zlib-devel`
 - **apk (Alpine/PostmarketOS)** `sudo apk add build-base cmake glew-dev glfw-dev sdl2-dev libogg-dev libtheora-dev libvorbis-dev`
-- Your favorite package manager here, [make a pull request](https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation/fork)
+- Your favorite package manager here, [make a pull request](https://github.com/FawkesRocks/New_Sonic_CD-R_Decompilation/fork)
 
 ## Android
 Follow the android build instructions [here.](./dependencies/android/README.md)
 
 ### Compiling
 
-In Command Prompt, use the "cd" command to change your directory like so. Remebemer to replace "[C:/Users/Fawkes/Github/New_Sonic_CD_R_Decompkication]" with the filepath to the source code you downloaded earlier.
+In Command Prompt, use the "cd" command to change your directory like so. Remember to replace "[C:/Users/Fawkes/Github/New_Sonic_CD-R_Decompilation]" with the filepath to the source code you downloaded earlier.
 ```
-cd [C:/Users/Fawkes/Github/New_Sonic_CD_R_Decompkication]
+cd [C:/Users/Fawkes/Github/New_Sonic_CD-R_Decompilation]
 ```
 
 
-Compiling is as simple as typing the following in the root repository directory. Make sure to run these commands one after the other, not together, or it wont work!:
+Compiling is as simple as typing the following in the root repository directory. Make sure to run these two commands one after another, otherwise the decompilation won't build:
 ```
 cmake -B build
 cmake --build build --config release
@@ -108,6 +108,8 @@ The following cmake arguments are available when compiling:
 
 ## Unofficial Branches
 Follow the installation instructions in the readme of each branch.
+
+**Non Restored:**
 * For the **Nintendo Switch**, go to [heyjoeway's fork](https://github.com/heyjoeway/Sonic-CD-11-Decompilation).
 * For the **Nintendo 3DS**, go to [SaturnSH2x2's fork](https://github.com/SaturnSH2x2/Sonic-CD-11-3DS).
   * A New Nintendo 3DS is required for the game to run smoothly.

--- a/README.md
+++ b/README.md
@@ -95,9 +95,10 @@ cmake --build build --config release
 
 The resulting build will be located somewhere in `build/` depending on your system.
 
-The following cmake arguments are available when compiling:
+> [!NOTE]
+You can use these arguments on the `cmake -B build` command like so: `cmake -B build -DRETRO_DISABLE_PLUS=on`
 
-### RSDKv3 flags
+The following cmake arguments are available when compiling:
 - `RETRO_DISABLE_PLUS`: Whether or not to disable the Plus DLC. Takes a boolean (on/off): build with `on` when compiling for distribution. Defaults to `off`.
 - `RETRO_FORCE_CASE_INSENSITIVE`: Forces case insensivity when loading files. Takes a boolean, defaults to `off`.
 - `RETRO_MOD_LOADER`: Enables or disables the mod loader. Takes a boolean, defaults to `on`.
@@ -105,7 +106,6 @@ The following cmake arguments are available when compiling:
 - `RETRO_ORIGINAL_CODE`: Removes any custom code. *A playable game will not be built with this enabled.* Takes a boolean, defaults to `off`.
 - `RETRO_SDL_VERSION`: *Only change this if you know what you're doing.* Switches between using SDL1 or SDL2. Takes an integer of either `1` or `2`, defaults to `2`.
 
-- Use these on the first `cmake -B build` step like so: `cmake -B build -DRETRO_DISABLE_PLUS=on`
 
 ## Unofficial Branches
 Follow the installation instructions in the readme of each branch.


### PR DESCRIPTION
fixes some errors seen in the readme, along with generally making it more clear. Also updated the workflow to use the new building method using cmake (with it running on commit unless you put [skip ci] in the commit name) and renaming the built executable to "Sonic CD Restored".