### PR TITLE
fixing building

### DIFF
--- a/platforms/Windows.cmake
+++ b/platforms/Windows.cmake
@@ -96,5 +96,5 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU
     target_compile_options(RetroEngine PRIVATE -Wno-microsoft-cast -Wno-microsoft-exception-spec)
 endif()
     
-target_sources(RetroEngine PRIVATE ${RETRO_NAME}/${RETRO_NAME}.rc)
+target_sources(RetroEngine PRIVATE RSDKv3/RSDKv3.rc)
 target_link_options(RetroEngine PRIVATE /subsystem:windows)


### PR DESCRIPTION
fixes building for windows(idk about linux) 
![image](https://github.com/user-attachments/assets/1cfbd74c-3a49-48b4-a66c-3ba57f42f0a1)
this used to output because it looked for "Sonic CD Restored.rc" in "Sonic CD Restored"(equivalent to RSDKv3/RSDKv3.rc)